### PR TITLE
Handle case when LDFLAGS = ""

### DIFF
--- a/XUPorter/XCBuildConfiguration.cs
+++ b/XUPorter/XCBuildConfiguration.cs
@@ -130,7 +130,9 @@ namespace UnityEditor.XCodeEditor
 				else if ( ((PBXDictionary)_data[BUILDSETTINGS_KEY])[ OTHER_LDFLAGS_KEY ] is string ) {
 					string tempString = (string)((PBXDictionary)_data[BUILDSETTINGS_KEY])[OTHER_LDFLAGS_KEY];
 					((PBXDictionary)_data[BUILDSETTINGS_KEY])[ OTHER_LDFLAGS_KEY ] = new PBXList();
-					((PBXList)((PBXDictionary)_data[BUILDSETTINGS_KEY])[OTHER_LDFLAGS_KEY]).Add( tempString );
+					if( !string.IsNullOrEmpty(tempString) ) {
+						((PBXList)((PBXDictionary)_data[BUILDSETTINGS_KEY])[OTHER_LDFLAGS_KEY]).Add( tempString );
+					}
 				}
 				
 				if( !((PBXList)((PBXDictionary)_data[BUILDSETTINGS_KEY])[OTHER_LDFLAGS_KEY]).Contains( flag ) ) {


### PR DESCRIPTION
Sometimes Xcode puts empty string to LDFLAGS when there are no flags. This changeset handles this situation and prevents empty string from being added to array of flags.
