### PR TITLE
needed for compatibility with cocoapods in XCode: the ability to use... 

### DIFF
--- a/XCProject.cs
+++ b/XCProject.cs
@@ -553,8 +553,9 @@ namespace UnityEditor.XCodeEditor
 					Debug.LogWarning ("not prepending a path to " + headerpath);
 					this.AddHeaderSearchPaths( headerpath );
 				} else {
-				string absoluteHeaderPath = System.IO.Path.Combine( mod.path, headerpath );
-				this.AddHeaderSearchPaths( absoluteHeaderPath );
+					string absoluteHeaderPath = System.IO.Path.Combine( mod.path, headerpath );
+					this.AddHeaderSearchPaths( absoluteHeaderPath );
+				}
 			}
 
 			Debug.Log( "Adding linker flags..." );


### PR DESCRIPTION
...“$(inherited)” in Header Search Paths.
