### PR TITLE
Unity 5 Support

### DIFF
--- a/PBX Editor/PBXBuildFile.cs
+++ b/PBX Editor/PBXBuildFile.cs
@@ -68,16 +68,11 @@ namespace UnityEditor.XCodeEditor
 			else {
 				attributes = settings[ ATTRIBUTES_KEY ] as PBXList;
 			}
-			
+
+			attributes.Remove( WEAK_VALUE );
 			if( weak ) {
 				attributes.Add( WEAK_VALUE );
 			}
-			else {
-				attributes.Remove( WEAK_VALUE );
-			}
-			
-			settings.Add( ATTRIBUTES_KEY, attributes );
-			this.Add( SETTINGS_KEY, settings );
 			
 			return true;
 		}

--- a/PBX Editor/PBXBuildFile.cs
+++ b/PBX Editor/PBXBuildFile.cs
@@ -12,16 +12,11 @@ namespace UnityEditor.XCodeEditor
 		private const string WEAK_VALUE = "Weak";
 		private const string COMPILER_FLAGS_KEY = "COMPILER_FLAGS";
 		
-		public PBXBuildFile( PBXFileReference fileRef, bool weak = false ) : base()
+		public PBXBuildFile( PBXFileReference fileRef, bool weak = false, string[] compilerFlags = null ) : base()
 		{
 			this.Add( FILE_REF_KEY, fileRef.guid );
 			SetWeakLink( weak );
-			
-			if (!string.IsNullOrEmpty(fileRef.compilerFlags))
-			{
-				foreach (var flag in fileRef.compilerFlags.Split(','))
-					AddCompilerFlag(flag);
-			}
+			AddCompilerFlags(compilerFlags);
 		}
 		
 		public PBXBuildFile( string guid, PBXDictionary dictionary ) : base ( guid, dictionary )
@@ -99,23 +94,35 @@ namespace UnityEditor.XCodeEditor
 		}
 
 		
-		public bool AddCompilerFlag( string flag )
+		public bool AddCompilerFlags( params string[] flags )
 		{
-			if( !_data.ContainsKey( SETTINGS_KEY ) )
-				_data[ SETTINGS_KEY ] = new PBXDictionary();
+			if( flags == null || flags.Length == 0)
+				return false;
+
+            object settingsObject;
+			PBXDictionary settings;
+
+            if( !_data.TryGetValue( SETTINGS_KEY, out settingsObject ) ) {
+				settings = new PBXDictionary();
+				_data[ SETTINGS_KEY ] = settings;
+			} else
+                settings = settingsObject as PBXDictionary;
 			
-			if( !((PBXDictionary)_data[ SETTINGS_KEY ]).ContainsKey( COMPILER_FLAGS_KEY ) ) {
-				((PBXDictionary)_data[ SETTINGS_KEY ]).Add( COMPILER_FLAGS_KEY, flag );
-				return true;
+			List<string> currentFlags = null;
+			if( settings.ContainsKey( COMPILER_FLAGS_KEY ) ) {
+                // merge specified with existing
+				currentFlags = new List<string>(((string)settings[ COMPILER_FLAGS_KEY ]).Split( ' ' ));
+
+				foreach( string flag in flags ) {
+					if( !currentFlags.Contains(flag) )
+                        currentFlags.Add(flag);
+				}
+			} else {
+				// no current flags so just use ones specified
+				currentFlags = new List<string>(flags);
 			}
-			
-			string[] flags = ((string)((PBXDictionary)_data[ SETTINGS_KEY ])[ COMPILER_FLAGS_KEY ]).Split( ' ' );
-			foreach( string item in flags ) {
-				if( item.CompareTo( flag ) == 0 )
-					return false;
-			}
-			
-			((PBXDictionary)_data[ SETTINGS_KEY ])[ COMPILER_FLAGS_KEY ] = ( string.Join( " ", flags ) + " " + flag );
+
+			settings[ COMPILER_FLAGS_KEY ] = string.Join( " ", currentFlags.ToArray() );
 			return true;
 		}
 		

--- a/PBX Editor/PBXFileReference.cs
+++ b/PBX Editor/PBXFileReference.cs
@@ -13,7 +13,6 @@ namespace UnityEditor.XCodeEditor
 		protected const string LASTKNOWN_FILE_TYPE_KEY = "lastKnownFileType";
 		protected const string ENCODING_KEY = "fileEncoding";
 		
-		public string compilerFlags;
 		public string buildPhase;
 		public readonly Dictionary<TreeEnum, string> trees = new Dictionary<TreeEnum, string> {
 			{ TreeEnum.ABSOLUTE, "<absolute>" },

--- a/PBX Editor/PBXParser.cs
+++ b/PBX Editor/PBXParser.cs
@@ -607,9 +607,8 @@ namespace UnityEditor.XCodeEditor
 				return true;
 			}
 
-			// FIX ME: Original regexp was: @"^[A-Za-z0-9_.]+$", we use modified regexp with '/-' allowed
-			//		   to workaround Unity bug when all PNGs had "Libraries/" (group name) added to their paths after append
-			if( !Regex.IsMatch( aString, @"^[A-Za-z0-9_./-]+$" ) ) {
+			// Escape any string values that don't match the following
+			if( !Regex.IsMatch( aString, @"^[A-Za-z0-9_./]+$" ) ) {
 				useQuotes = true;
 			}
 

--- a/XCProject.cs
+++ b/XCProject.cs
@@ -707,70 +707,87 @@ namespace UnityEditor.XCodeEditor
 		public void ApplyMod( XCMod mod )
 		{	
 			PBXGroup modGroup = this.GetGroup( mod.group );
-			
-			Debug.Log( "Adding libraries..." );
-			
-			foreach( XCModFile libRef in mod.libs ) {
-				string completeLibPath = System.IO.Path.Combine( "usr/lib", libRef.filePath );
-				Debug.Log ("Adding library " + completeLibPath);
-				this.AddFile( completeLibPath, modGroup, "SDKROOT", true, libRef.isWeak );
-			}
-			
-			Debug.Log( "Adding frameworks..." );
-			PBXGroup frameworkGroup = this.GetGroup( "Frameworks" );
-			foreach( string framework in mod.frameworks ) {
-				string[] filename = framework.Split( ':' );
-				bool isWeak = ( filename.Length > 1 ) ? true : false;
-				string completePath = System.IO.Path.Combine( "System/Library/Frameworks", filename[0] );
-				this.AddFile( completePath, frameworkGroup, "SDKROOT", true, isWeak );
-			}
 
-			Debug.Log( "Adding files..." );
-			foreach( string filePath in mod.files ) {
-				string absoluteFilePath = System.IO.Path.Combine( mod.path, filePath );
-				this.AddFile( absoluteFilePath, modGroup );
-			}
-
-			Debug.Log( "Adding embed binaries..." );
-			if (mod.embed_binaries != null)
-			{
-				//1. Add LD_RUNPATH_SEARCH_PATHS for embed framework
-				this.overwriteBuildSetting("LD_RUNPATH_SEARCH_PATHS", "$(inherited) @executable_path/Frameworks", "Release");
-				this.overwriteBuildSetting("LD_RUNPATH_SEARCH_PATHS", "$(inherited) @executable_path/Frameworks", "Debug");
-
-				foreach( string binary in mod.embed_binaries ) {
-					string absoluteFilePath = System.IO.Path.Combine( mod.path, binary );
-					this.AddEmbedFramework(absoluteFilePath);
-				}
-			}
-			
-			Debug.Log( "Adding folders..." );
-			foreach( string folderPath in mod.folders ) {
-				string absoluteFolderPath = System.IO.Path.Combine( Application.dataPath, folderPath );
-				Debug.Log ("Adding folder " + absoluteFolderPath);
-				this.AddFolder( absoluteFolderPath, modGroup, (string[])mod.excludes.ToArray( typeof(string) ) );
-			}
-			
-			Debug.Log( "Adding headerpaths..." );
-			foreach( string headerpath in mod.headerpaths ) {
-				if (headerpath.Contains("$(inherited)")) {
-					Debug.Log ("not prepending a path to " + headerpath);
-					this.AddHeaderSearchPaths( headerpath );
-				} else {
-					string absoluteHeaderPath = System.IO.Path.Combine( mod.path, headerpath );
-					this.AddHeaderSearchPaths( absoluteHeaderPath );
+			if (mod.libs != null) {
+				Debug.Log( "Adding libraries..." );
+				
+				foreach( XCModFile libRef in mod.libs ) {
+					string completeLibPath = System.IO.Path.Combine( "usr/lib", libRef.filePath );
+					Debug.Log ("Adding library " + completeLibPath);
+					this.AddFile( completeLibPath, modGroup, "SDKROOT", true, libRef.isWeak );
 				}
 			}
 
-			Debug.Log( "Adding compiler flags..." );
-			foreach( string flag in mod.compiler_flags ) {
-				this.AddOtherCFlags( flag );
+			if (mod.frameworks != null) {
+				Debug.Log( "Adding frameworks..." );
+				PBXGroup frameworkGroup = this.GetGroup( "Frameworks" );
+				foreach( string framework in mod.frameworks ) {
+					string[] filename = framework.Split( ':' );
+					bool isWeak = ( filename.Length > 1 ) ? true : false;
+					string completePath = System.IO.Path.Combine( "System/Library/Frameworks", filename[0] );
+					this.AddFile( completePath, frameworkGroup, "SDKROOT", true, isWeak );
+				}
 			}
 
-			Debug.Log( "Adding linker flags..." );
-			foreach( string flag in mod.linker_flags ) {
-				this.AddOtherLinkerFlags( flag );
+			if (mod.files != null) {
+				Debug.Log( "Adding files..." );
+				foreach( string filePath in mod.files ) {
+					string absoluteFilePath = System.IO.Path.Combine( mod.path, filePath );
+					this.AddFile( absoluteFilePath, modGroup );
+				}
 			}
+
+			if (mod.embed_binaries != null) {
+				Debug.Log( "Adding embed binaries..." );
+				if (mod.embed_binaries != null)
+				{
+					//1. Add LD_RUNPATH_SEARCH_PATHS for embed framework
+					this.overwriteBuildSetting("LD_RUNPATH_SEARCH_PATHS", "$(inherited) @executable_path/Frameworks", "Release");
+					this.overwriteBuildSetting("LD_RUNPATH_SEARCH_PATHS", "$(inherited) @executable_path/Frameworks", "Debug");
+
+					foreach( string binary in mod.embed_binaries ) {
+						string absoluteFilePath = System.IO.Path.Combine( mod.path, binary );
+						this.AddEmbedFramework(absoluteFilePath);
+					}
+				}
+			}
+
+			if (mod.folders != null) {
+				Debug.Log( "Adding folders..." );
+				foreach( string folderPath in mod.folders ) {
+					string absoluteFolderPath = System.IO.Path.Combine( Application.dataPath, folderPath );
+					Debug.Log ("Adding folder " + absoluteFolderPath);
+					this.AddFolder( absoluteFolderPath, modGroup, (string[])mod.excludes.ToArray( typeof(string) ) );
+				}
+			}
+
+			if (mod.headerpaths != null) {
+				Debug.Log( "Adding headerpaths..." );
+				foreach( string headerpath in mod.headerpaths ) {
+					if (headerpath.Contains("$(inherited)")) {
+						Debug.Log ("not prepending a path to " + headerpath);
+						this.AddHeaderSearchPaths( headerpath );
+					} else {
+						string absoluteHeaderPath = System.IO.Path.Combine( mod.path, headerpath );
+						this.AddHeaderSearchPaths( absoluteHeaderPath );
+					}
+				}
+			}
+
+			if (mod.compiler_flags != null) {
+				Debug.Log( "Adding compiler flags..." );
+				foreach( string flag in mod.compiler_flags ) {
+					this.AddOtherCFlags( flag );
+				}
+			}
+
+			if (mod.linker_flags != null) {
+				Debug.Log( "Adding linker flags..." );
+				foreach( string flag in mod.linker_flags ) {
+					this.AddOtherLinkerFlags( flag );
+				}
+			}
+
 
 			this.Consolidate();
 		}

--- a/XCodePostProcess.cs
+++ b/XCodePostProcess.cs
@@ -18,7 +18,6 @@ public static class XCodePostProcess
 #else
         if (target != BuildTarget.iPhone) {
 #endif
-			Debug.LogWarning("Target is not iPhone. XCodePostProcess will not run");
 			return;
 		}
 

--- a/XCodePostProcess.cs
+++ b/XCodePostProcess.cs
@@ -13,7 +13,11 @@ public static class XCodePostProcess
 	[PostProcessBuild(999)]
 	public static void OnPostProcessBuild( BuildTarget target, string pathToBuiltProject )
 	{
-		if (target != BuildTarget.iPhone) {
+#if UNITY_5
+		if (target != BuildTarget.iOS) {
+#else
+        if (target != BuildTarget.iPhone) {
+#endif
 			Debug.LogWarning("Target is not iPhone. XCodePostProcess will not run");
 			return;
 		}


### PR DESCRIPTION
Hey there,

I ran into a few issues while getting our projects working with Unity 5 and wanted to share the fixes as some people might find them helpful:
- When an Xcode project was loaded by Unity (during an append) we would see an exception being thrown because the path values that contained "-" for some file references were not quote escaped. 
- Unity seems to add file references with no build phase which meant when adding a projmod addition for e.g. AdSupport.framework it was ignored. Had to make some changes to allow phase changes and also detecting duplicate build files being added.

Feel free to let me know if you need anything changed.

Cheers,
Ramon.
