### PR TITLE
buildConfigName = "all" should match every buildConfig

### DIFF
--- a/XCProject.cs
+++ b/XCProject.cs
@@ -274,8 +274,8 @@ namespace UnityEditor.XCodeEditor
 			foreach( KeyValuePair<string, XCBuildConfiguration> buildConfig in buildConfigurations ) {
 				//Debug.Log ("build config " + buildConfig);
 				XCBuildConfiguration b = buildConfig.Value;
-				if ( (string)b.data["name"] == buildConfigName || (string)b.data["name"] == "all") {
-					//Debug.Log ("found " + buildConfigName + " config");
+				if ( (string)b.data["name"] == buildConfigName || (string)buildConfigName == "all") {
+					//Debug.Log ("found " + b.data["name"] + " config");
 					buildConfig.Value.overwriteBuildSetting(settingName, newValue);
 					modified = true;
 				} else {


### PR DESCRIPTION
Right now it only matches build configs with the name "all" which I don't think is the intention.