### PR TITLE
add support for tbd files

### DIFF
--- a/PBX Editor/PBXFileReference.cs
+++ b/PBX Editor/PBXFileReference.cs
@@ -46,7 +46,8 @@ namespace UnityEditor.XCodeEditor
 			{ ".xib", "file.xib" },
 			{ ".strings", "text.plist.strings" },
 			{ ".bundle", "wrapper.plug-in" },
-			{ ".dylib", "compiled.mach-o.dylib" },			
+			{ ".dylib", "compiled.mach-o.dylib" },
+			{ ".tbd", "sourcecode.text-based-dylib-definition" },
 			{ ".json", "text.json" }
    		 };
 		
@@ -73,7 +74,8 @@ namespace UnityEditor.XCodeEditor
 			{ ".xib", "PBXResourcesBuildPhase" },
 			{ ".strings", "PBXResourcesBuildPhase" },
 			{ ".bundle", "PBXResourcesBuildPhase" },
-			{ ".dylib", "PBXFrameworksBuildPhase" }
+			{ ".dylib", "PBXFrameworksBuildPhase" },
+			{ ".tbd", "PBXFrameworksBuildPhase" }
     	};
 		
 		public PBXFileReference( string guid, PBXDictionary dictionary ) : base( guid, dictionary )


### PR DESCRIPTION
I work with Xcode 7.3, Unity 4.7.1
when i try to add libc++.tbd, it does not work well.
I find .tbd file type is not in type map, so just add it, and it works now.

Please review it. thanks.